### PR TITLE
refactor: refactor delete pool and withdraw token from pool

### DIFF
--- a/nep141-token-convertor-contract/src/admin.rs
+++ b/nep141-token-convertor-contract/src/admin.rs
@@ -3,17 +3,6 @@ use crate::types::FtMetaData;
 use crate::*;
 
 #[near_bindgen]
-impl TokenConvertor {
-    pub(crate) fn assert_admin_access(&self) {
-        assert_eq!(
-            self.admin,
-            env::predecessor_account_id(),
-            "require admin access permission."
-        );
-    }
-}
-
-#[near_bindgen]
 impl AdminAction for TokenConvertor {
     fn extend_whitelisted_tokens(&mut self, tokens: Vec<FtMetaData>) {
         self.assert_admin_access();

--- a/nep141-token-convertor-contract/src/contract_interfaces.rs
+++ b/nep141-token-convertor-contract/src/contract_interfaces.rs
@@ -30,7 +30,14 @@ pub trait PoolCreatorAction {
         out_token_rate: u32,
     ) -> u32;
 
-    fn withdraw_token_in_pool(&mut self, pool_id: PoolId, token_id: AccountId, amount: U128);
+    /// only pool creator or admin can withdraw token in pool
+    /// if amount is Option::None, it means withdraw all
+    fn withdraw_token_in_pool(
+        &mut self,
+        pool_id: PoolId,
+        token_id: AccountId,
+        amount: Option<U128>,
+    );
 
     fn delete_pool(&mut self, pool_id: PoolId);
 }

--- a/nep141-token-convertor-contract/src/lib.rs
+++ b/nep141-token-convertor-contract/src/lib.rs
@@ -94,6 +94,24 @@ impl TokenConvertor {
                 - account.near_amount_for_storage
         );
     }
+
+    pub(crate) fn assert_remind_gas_greater_then(&self, gas: Gas) {
+        let remind_gas = env::prepaid_gas() - env::used_gas();
+        assert!(
+            remind_gas > gas,
+            "Need at least {} gas to go on, but only remind {} gas",
+            gas.0,
+            remind_gas.0
+        );
+    }
+
+    pub(crate) fn assert_admin_access(&self) {
+        assert_eq!(
+            self.admin,
+            env::predecessor_account_id(),
+            "require admin access permission."
+        );
+    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -101,7 +119,7 @@ impl TokenConvertor {
 pub mod test {
     use crate::TokenConvertor;
     use near_sdk::test_utils::{accounts, VMContextBuilder};
-    use near_sdk::{testing_env, AccountId, VMContext};
+    use near_sdk::{testing_env, AccountId};
     use std::convert::TryFrom;
 
     pub fn string_to_account(name: &str) -> AccountId {

--- a/nep141-token-convertor-contract/src/token_receiver.rs
+++ b/nep141-token-convertor-contract/src/token_receiver.rs
@@ -82,6 +82,9 @@ impl TokenConvertor {
         amount: Balance,
     ) -> Promise {
         self.assert_storage_balance_bound_min(receiver_id);
+        let ft_transfer_gas = Gas::ONE_TERA.mul(T_GAS_FOR_FT_TRANSFER);
+        let ft_transfer_resolved_gas = Gas::ONE_TERA.mul(T_GAS_FOR_RESOLVE_TRANSFER);
+        self.assert_remind_gas_greater_then(ft_transfer_gas + ft_transfer_resolved_gas);
         ext_fungible_token::ft_transfer(
             receiver_id.clone(),
             U128(amount),

--- a/nep141-token-convertor-contract/tests/common/convertor.rs
+++ b/nep141-token-convertor-contract/tests/common/convertor.rs
@@ -145,7 +145,7 @@ impl Convertor {
         signer: &UserAccount,
         pool_id: PoolId,
         token_id: AccountId,
-        amount: U128,
+        amount: Option<U128>,
     ) -> ExecutionResult {
         let contract = &self.contract;
         let result = call!(

--- a/nep141-token-convertor-contract/tests/test_pool.rs
+++ b/nep141-token-convertor-contract/tests/test_pool.rs
@@ -98,13 +98,26 @@ fn test_deposit_withdraw_delete() {
             &creator,
             1,
             whitelist_tokens[0].token_id.clone(),
-            U128::from(5),
+            Option::None,
+        )
+        .assert_success();
+    assert_eq!(
+        0,
+        convertor.get_pools(0, 1).pop().unwrap().in_token_balance.0
+    );
+
+    convertor
+        .withdraw_token(
+            &creator,
+            1,
+            whitelist_tokens[1].token_id.clone(),
+            Option::None,
         )
         .assert_success();
 
     assert_eq!(
-        5,
-        convertor.get_pools(0, 1).pop().unwrap().in_token_balance.0
+        0,
+        convertor.get_pools(0, 1).pop().unwrap().out_token_balance.0
     );
 
     should_failed(&convertor.delete_pool(&root, 1));


### PR DESCRIPTION
- Changing param: amount type from U128 into Option<U128> in `withdraw_token_in_pool`,if amount is Option::None,it means withdraw all tokens.
- Changing check logic in `withdraw_token_in_pool`,now it allows admin withdraw token.
- Changing `delete_pool` logic,requiring withdraw all in_token and out_token in pool before deleting pool.
- Adding a check of gas when `internal_send_token`.Requring remind gas must more than gas of `ft_transfer` and `ft_transfer_resolved` need.